### PR TITLE
Add basic tab content to SwiftUI app

### DIFF
--- a/StyloApp/StyloApp/ContentView.swift
+++ b/StyloApp/StyloApp/ContentView.swift
@@ -9,13 +9,22 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                }
+
+            ExploreView()
+                .tabItem {
+                    Label("Explore", systemImage: "magnifyingglass")
+                }
+
+            SettingsView()
+                .tabItem {
+                    Label("Settings", systemImage: "gearshape")
+                }
         }
-        .padding()
     }
 }
 

--- a/StyloApp/StyloApp/ExploreView.swift
+++ b/StyloApp/StyloApp/ExploreView.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ExploreView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "magnifyingglass")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 80, height: 80)
+                .foregroundStyle(.purple)
+            Text("Explore new styles and trends")
+                .font(.title2)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    ExploreView()
+}

--- a/StyloApp/StyloApp/HomeView.swift
+++ b/StyloApp/StyloApp/HomeView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "house.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 80, height: 80)
+                .foregroundStyle(.blue)
+            Text("Welcome to the Home tab")
+                .font(.title2)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/StyloApp/StyloApp/SettingsView.swift
+++ b/StyloApp/StyloApp/SettingsView.swift
@@ -1,0 +1,20 @@
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "gearshape.fill")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 80, height: 80)
+                .foregroundStyle(.green)
+            Text("Adjust your preferences")
+                .font(.title2)
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    SettingsView()
+}


### PR DESCRIPTION
## Summary
- Implement a TabView in `ContentView` with Home, Explore, and Settings tabs
- Create individual SwiftUI views with simple icons and descriptions for each tab

## Testing
- `swiftc ContentView.swift ExploreView.swift HomeView.swift SettingsView.swift StyloAppApp.swift -o StyloAppExecutable` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_68ab8af14c5c8324bd928eb068edc280